### PR TITLE
Fix SQL syntax error when modelName is reserved

### DIFF
--- a/packages/model-data-generator/src/references.js
+++ b/packages/model-data-generator/src/references.js
@@ -41,7 +41,7 @@ const references = async (DTO, uniqueObj) => {
         }
         const db = await database.getPool();
         const [record] = await db
-          .query(`SELECT ${modelToQuery.key} FROM ${modelName} ORDER BY RAND() LIMIT 1`)
+          .query(`SELECT ${modelToQuery.key} FROM \`${modelName}\` ORDER BY RAND() LIMIT 1`)
           .then(([results]) => results)
           .catch((error) => {
             errors.push(error.message);


### PR DESCRIPTION
If model name is a SQL reserved keyword like 'group,' the generation fails with a syntax error.